### PR TITLE
Remove redundant root route from main app entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,7 @@
 from app import create_app
+
 app = create_app()
-import os
 
-print(os.getenv("DATABASE_URL"))
-
-@app.get("/")
-def ping():
-    return {"ok": True, "msg": "alive"}
 
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
## Summary
- streamline main module to only create and run the Flask app
- rely on existing health check in `app/__init__.py` for GET /

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895d5f835f0832eb1d4f68db730f388